### PR TITLE
fix: multiplePeriodo, calendario_mid udistrital/sga_documentacion#695

### DIFF
--- a/services/consulta_calendario_academico_service.go
+++ b/services/consulta_calendario_academico_service.go
@@ -840,6 +840,10 @@ func GetCalendarInfo(idCalendario string) (interface{}, error) {
 					ExisteExtension = true
 				}
 
+				if calendarioAux["MultiplePeriodoId"] == nil {
+					calendarioAux["MultiplePeriodoId"] = ""
+				}
+
 				resultado = map[string]interface{}{
 					"Id":                      idCalendario,
 					"Nombre":                  calendarioAux["Nombre"].(string),


### PR DESCRIPTION
Corrección para el campo MultiplePeriodoId que no existe en el modelo de base de datos de producción.